### PR TITLE
Update links to point to the new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # CImGui
 
-[![Build Status](https://github.com/Gnimuc/CImGui.jl/workflows/CI/badge.svg)](https://github.com/Gnimuc/CImGui.jl/actions/workflows/ci.yml)
+[![Build Status](https://github.com/JuliaImGui/CImGui.jl/workflows/CI/badge.svg)](https://github.com/JuliaImGui/CImGui.jl/actions/workflows/ci.yml)
 [![pkgeval](https://juliahub.com/docs/CImGui/pkgeval.svg)](https://juliahub.com/ui/Packages/CImGui/HqG2H)
 [![version](https://juliahub.com/docs/General/CImGui/stable/version.svg)](https://juliahub.com/ui/Packages/General/CImGui)
-[![codecov](https://codecov.io/gh/Gnimuc/CImGui.jl/graph/badge.svg?token=KLCkl2pB7N)](https://codecov.io/gh/Gnimuc/CImGui.jl)
+[![codecov](https://codecov.io/gh/JuliaImGui/CImGui.jl/graph/badge.svg?token=KLCkl2pB7N)](https://codecov.io/gh/JuliaImGui/CImGui.jl)
 [![](https://img.shields.io/badge/design%20principle-KISS-orange)](https://en.wikipedia.org/wiki/KISS_principle)
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://Gnimuc.github.io/CImGui.jl/stable)
-[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://Gnimuc.github.io/CImGui.jl/dev)
-![GitHub Discussions](https://img.shields.io/github/discussions/Gnimuc/CImGui.jl)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaImGui.github.io/CImGui.jl/stable)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaImGui.github.io/CImGui.jl/dev)
+![GitHub Discussions](https://img.shields.io/github/discussions/JuliaImGui/CImGui.jl)
 [![deps](https://juliahub.com/docs/CImGui/deps.svg)](https://juliahub.com/ui/Packages/CImGui/HqG2H?t=2)
 
 This package provides a Julia language wrapper for
@@ -20,4 +20,4 @@ use cases.
 
 ![demo](demo/demo.png)
 
-See the [documentation](https://Gnimuc.github.io/CImGui.jl/stable) for more info.
+See the [documentation](https://juliaimgui.github.io/CImGui.jl/stable) for more info.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,7 @@ Changelog.generate(
     Changelog.Documenter(),
     joinpath(@__DIR__, "src/_changelog.md"),
     joinpath(@__DIR__, "src/changelog.md"),
-    repo="Gnimuc/CImGui.jl"
+    repo="JuliaImGui/CImGui.jl"
 )
 
 makedocs(;
@@ -21,7 +21,7 @@ makedocs(;
     sitename="CImGui.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://Gnimuc.github.io/CImGui.jl",
+        canonical="https://juliaimgui.github.io/CImGui.jl",
         assets=String[],
         size_threshold=2_000_000,
         size_threshold_warn=1_500_000
@@ -30,5 +30,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/Gnimuc/CImGui.jl.git",
+    repo="github.com/JuliaImGui/CImGui.jl.git",
 )

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -6,7 +6,7 @@ CurrentModule = CImGui
 This documents notable changes in CImGui.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
-## [v4.0.0] - 2024-11-19
+## [v4.0.0] - 2024-12-21
 
 ### Changed
 - **Breaking**: We updated to [Dear ImGui
@@ -22,7 +22,7 @@ Changelog](https://keepachangelog.com).
     respectively.
 
   For Linux/GLFW users, there's also a fix for a long-standing docking bug:
-  https://github.com/ocornut/imgui/issues/7733
+  <https://github.com/ocornut/imgui/issues/7733>
 
 ## [v3.1.1] - 2024-11-05
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -44,7 +44,7 @@ julia> julia_demo()
 ```
 
 [All of these
-examples](https://github.com/Gnimuc/CImGui.jl/tree/master/examples) are
+examples](https://github.com/JuliaImGui/CImGui.jl/tree/master/examples) are
 one-to-one ported from [Dear ImGui's C++
 examples](https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp) and there
 is an [interactive

--- a/docs/src/makie.md
+++ b/docs/src/makie.md
@@ -21,7 +21,7 @@ It supports all the interaction features in GLMakie:
 - Ctrl + left click to reset the limits
 
 Here's a quick demo using
-[`examples/makie_demo.jl`](https://github.com/Gnimuc/CImGui.jl/blob/master/examples/makie_demo.jl)
+[`examples/makie_demo.jl`](https://github.com/JuliaImGui/CImGui.jl/blob/master/examples/makie_demo.jl)
 (you may want to `Right click -> Open in new tab` to see it in full resolution):
 ![Makie demo](assets/makie-demo.gif)
 

--- a/src/CImGui.jl
+++ b/src/CImGui.jl
@@ -95,7 +95,7 @@ end
                 tooltip=true, stats=false)
 
 Display a Makie figure in ImGui. See
-[`examples/makie_demo.jl`](https://github.com/Gnimuc/CImGui.jl/blob/master/examples/makie_demo.jl)
+[`examples/makie_demo.jl`](https://github.com/JuliaImGui/CImGui.jl/blob/master/examples/makie_demo.jl)
 for an example of how to use it.
 
 These are the [interaction


### PR DESCRIPTION
Also updated the changelog a bit.

I'll go ahead and tag v4 after this since Github handles the repo redirect when cloning (see https://github.com/JuliaRegistries/General/pull/121788).