### PR TITLE
Add precompilation workloads and bump version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,41 +12,6 @@ permissions:
   contents: read
 
 jobs:
-  loading:
-    name: Loading only - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1.9'
-          - '1'
-          - 'nightly'
-        os:
-          - macOS-latest
-          - windows-latest
-        arch:
-          - x64
-          - x86
-        exclude:
-          - os: macOS-latest
-            arch: x86
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-
-      # We add ModernGL and GLFW so that the backend extensions will be loaded too
-      - run: |
-          julia --project=. -e '
-          using Pkg
-          Pkg.add(["ModernGL", "GLFW"])
-          import CImGui, ModernGL, GLFW
-          '
-
   tests:
     name: Tests - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CImGui"
 uuid = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "5.0.0"
+version = "5.0.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -9,6 +9,7 @@ CImGuiPack_jll = "333409e9-af72-5310-9767-d6ad21a76a05"
 CSyntax = "ea656a56-6ca6-5dda-bba5-7b6963a5f74c"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
@@ -30,6 +31,7 @@ DocStringExtensions = "0.9.3"
 GLFW = "3"
 GLMakie = "0.10.6, 0.11"
 ModernGL = "1"
+PrecompileTools = "1.2.1"
 Printf = "1"
 Statistics = "1"
 julia = "1.9"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,7 +24,7 @@ makedocs(;
         canonical="https://juliaimgui.github.io/CImGui.jl",
         assets=String[],
         size_threshold=2_000_000,
-        size_threshold_warn=1_500_000
+        size_threshold_warn=2_000_000
     ),
     pages=["index.md", "api.md", "backends.md", "makie.md", "changelog.md"]
 )

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -6,6 +6,19 @@ CurrentModule = CImGui
 This documents notable changes in CImGui.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v5.0.1] - 2025-02-17
+
+### Changed
+- Added precompilation workloads for the GLFW/OpenGL backend and the Makie
+  extension ([#165]). This reduced the execution time of some tests involving the
+  GLFW/OpenGL backend from ~2.5s to ~1.8s, and the execution time of the Makie
+  integration tests from ~15s to ~5s.
+
+  It is possible that the workloads are not portable: if you get a
+  precompilation error please report it as a bug with the error message. The
+  precompilation workloads can be disabled completely [using the PrecompileTools
+  preferences](https://julialang.github.io/PrecompileTools.jl/stable/#Package-developers:-reducing-the-cost-of-precompilation-during-development).
+
 ## [v5.0.0] - 2025-02-05
 
 ### Changed

--- a/src/CImGui.jl
+++ b/src/CImGui.jl
@@ -143,7 +143,7 @@ function _update_image_texture end
 function _destroy_image_texture end
 function _current_window end
 
-const _backend = Ref{Symbol}()
+_backend::Union{Symbol, Nothing} = nothing
 
 """
     set_backend(backend::Symbol)
@@ -156,11 +156,11 @@ function set_backend(backend::Symbol)
         throw(ArgumentError("Unrecognized backend: $(backend)"))
     end
 
-    global _backend[] = backend
+    global _backend = backend
 end
 
 function _check_backend()
-    if !isassigned(_backend)
+    if isnothing(_backend)
         error("You must call `CImGui.set_backend()` to the backend you want before calling this function, e.g. `CImGui.set_backend(:GlfwOpenGL3)` for the GLFW/OpenGL3 backend.")
     end
 end
@@ -227,27 +227,27 @@ Keyword arguments:
 """
 function render(args...; kwargs...)
     _check_backend()
-    _render(args..., Val(_backend[]); kwargs...)
+    _render(args..., Val(_backend); kwargs...)
 end
 
 function current_window()
     _check_backend()
-    _current_window(Val(_backend[]))
+    _current_window(Val(_backend))
 end
 
 function create_image_texture(args...; kwargs...)
     _check_backend()
-    _create_image_texture(Val(_backend[]), args...; kwargs...)
+    _create_image_texture(Val(_backend), args...; kwargs...)
 end
 
 function update_image_texture(args...; kwargs...)
     _check_backend()
-    _update_image_texture(Val(_backend[]), args...; kwargs...)
+    _update_image_texture(Val(_backend), args...; kwargs...)
 end
 
 function destroy_image_texture(args...; kwargs...)
     _check_backend()
-    _destroy_image_texture(Val(_backend[]), args...; kwargs...)
+    _destroy_image_texture(Val(_backend), args...; kwargs...)
 end
 
 ## Test engine


### PR DESCRIPTION
This did require removing the loading tests from CI since they will now try to create a GLFW window etc, which is not supported on mac or windows.