### PR TITLE
Added an option to use `WaitEvents()` instead of `PollEvents()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CImGui"
 uuid = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "5.0.1"
+version = "5.1.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -6,6 +6,12 @@ CurrentModule = CImGui
 This documents notable changes in CImGui.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v5.1.0] - 2025-02-19
+- Added an option to call WaitEvents() instead of PollEvents() in render loop ([#164]).
+  You can use it by passing keyword argument `wait_events=true` in function [`render()`](@ref)
+
+### Changed
+
 ## [v5.0.1] - 2025-02-17
 
 ### Changed

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,10 +7,10 @@ This documents notable changes in CImGui.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
 ## [v5.1.0] - 2025-02-19
-- Added an option to call WaitEvents() instead of PollEvents() in render loop ([#164]).
-  You can use it by passing keyword argument `wait_events=true` in function [`render()`](@ref)
 
 ### Changed
+- Added an option to call WaitEvents() instead of PollEvents() in render loop ([#164]).
+  You can use it by passing keyword argument `wait_events=true` in function [`render()`](@ref)
 
 ## [v5.0.1] - 2025-02-17
 

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -9,7 +9,7 @@ Changelog](https://keepachangelog.com).
 ## [v5.1.0] - 2025-02-19
 
 ### Changed
-- Added an option to call WaitEvents() instead of PollEvents() in render loop ([#164]).
+- Added an option to call WaitEvents() instead of PollEvents() in render loop ([#166]).
   You can use it by passing keyword argument `wait_events=true` in function [`render()`](@ref)
 
 ## [v5.0.1] - 2025-02-17

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -8,7 +8,7 @@ Changelog](https://keepachangelog.com).
 
 ## [v5.1.0] - 2025-02-19
 
-### Changed
+### Added
 - Added an option to call WaitEvents() instead of PollEvents() in render loop ([#166]).
   You can use it by passing keyword argument `wait_events=true` in function [`render()`](@ref)
 

--- a/ext/GlfwOpenGLBackend.jl
+++ b/ext/GlfwOpenGLBackend.jl
@@ -60,7 +60,8 @@ function renderloop(ui, ctx::Ptr{lib.ImGuiContext}, ::Val{:GlfwOpenGL3};
                     window_size=(1280, 720),
                     window_title="CImGui",
                     engine=nothing,
-                    opengl_version=v"3.2")
+                    opengl_version=v"3.2",
+                    wait_events=false)
     # Validate arguments
     if clear_color isa Ref && !isassigned(clear_color)
         throw(ArgumentError("'clear_color' is a unassigned reference, it must be initialized properly."))
@@ -98,7 +99,7 @@ function renderloop(ui, ctx::Ptr{lib.ImGuiContext}, ::Val{:GlfwOpenGL3};
 
     try
         while !GLFW.WindowShouldClose(window)
-            GLFW.PollEvents()
+            wait_events ? GLFW.WaitEvents() : GLFW.PollEvents()
 
             # Start the Dear ImGui frame
             lib.ImGui_ImplOpenGL3_NewFrame()

--- a/src/CImGui.jl
+++ b/src/CImGui.jl
@@ -197,6 +197,7 @@ Keyword arguments:
   any tests registered with the test engine they will be queued and run
   automatically.
 - `opengl_version::VersionNumber=v"3.2"`: The OpenGL version to use.
+- `wait_events=false`: Disable calling `WaitEvents()` instead of `PollEvents()`.
 - `spawn::Union{Bool, Integer, Symbol}=1`: How/where to spawn the
   renderloop. It defaults to thread 1 for safety, but note that currently Julia
   also uses thread 1 to run the libuv event loop:

--- a/src/CImGui.jl
+++ b/src/CImGui.jl
@@ -197,7 +197,8 @@ Keyword arguments:
   any tests registered with the test engine they will be queued and run
   automatically.
 - `opengl_version::VersionNumber=v"3.2"`: The OpenGL version to use.
-- `wait_events=false`: Disable calling `WaitEvents()` instead of `PollEvents()`.
+- `wait_events=false`: Set to `true` to call `GLFW.WaitEvents()` instead of
+  `GLFW.PollEvents()` (only supported for the GLFW/OpenGL backend).
 - `spawn::Union{Bool, Integer, Symbol}=1`: How/where to spawn the
   renderloop. It defaults to thread 1 for safety, but note that currently Julia
   also uses thread 1 to run the libuv event loop:


### PR DESCRIPTION
I sometimes use `WaitEvents()` insead of `PollEvents()` in render loop to optimize event handling, but in latest versions of CImGui there is no way to customize render functions, defined in GlfwOpenGLBackend extension, so I think it would be helpful for more then just me to add the option to choose between `WaitEvents()` and `PollEvents()`.